### PR TITLE
Add login persistence and tray support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,35 @@ portable theme on other platforms.
 
 Start the GUI with:
 
+```bash
 python social_gui.py
+```
+
+The first time you launch the application it will ask for a folder to store
+profile backups and whether the program should continue running in the
+background when the window is closed. Once a profile has been created the
+application will automatically sign in using the saved data.
+
+### Command line usage (for debugging)
+
+The command line script can still be used for experimenting with the network:
+
+```bash
+python social_p2p.py --username alice --port 8468
+```
+
+## FAQ
+
+**Where is my profile stored?**  By default a folder named `.p2psocial` is
+created in your home directory. This folder holds your configuration file and a
+backup of your profile data which can be copied for safekeeping.
+
+**How do I restore my account?**  Place your saved profile JSON back into the
+data folder and ensure the configuration file points to the same username. The
+program will automatically load it on start.
+
+## Technical Notes
+
+The network layer relies on the `kademlia` package to publish profile details
+and exchange messages using a DHT. The GUI is implemented with Tkinter and can
+optionally minimize to the system tray using `pystray`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 kademlia==2.2.3
+pystray==0.19.5
+Pillow==11.3.0

--- a/social_gui.py
+++ b/social_gui.py
@@ -1,8 +1,16 @@
 import sys
+import os
+import json
 import asyncio
 import tkinter as tk
-from tkinter import ttk, messagebox
+from tkinter import ttk, messagebox, filedialog
+from pathlib import Path
+from PIL import Image, ImageDraw
+import pystray
 from social_p2p import Peer, DEFAULT_PORT
+
+DEFAULT_DATA_DIR = Path.home() / '.p2psocial'
+CONFIG_FILE = 'config.json'
 
 
 class App(tk.Tk):
@@ -20,7 +28,49 @@ class App(tk.Tk):
             pass  # fallback to default theme
 
         self.peer = None
-        self.create_connect_frame()
+        self.tray = None
+        self.protocol('WM_DELETE_WINDOW', self.on_close)
+
+        self.config_data = {}
+        self.data_dir = DEFAULT_DATA_DIR
+        self.minimize_to_tray = False
+        self.load_or_setup()
+
+    # -------- Configuration management ---------
+    def load_or_setup(self):
+        cfg_path = self.data_dir / CONFIG_FILE
+        if cfg_path.exists():
+            try:
+                self.config_data = json.load(open(cfg_path, 'r', encoding='utf-8'))
+                self.minimize_to_tray = self.config_data.get('minimize_to_tray', False)
+                self.data_dir = Path(self.config_data.get('data_dir', self.data_dir))
+            except Exception:
+                self.config_data = {}
+        else:
+            self.first_time_setup()
+            self.save_config()
+
+        username = self.config_data.get('username')
+        if username and (self.data_dir / f"{username}_profile.json").exists():
+            self.username_var = tk.StringVar(value=username)
+            self.port_var = tk.IntVar(value=self.config_data.get('port', DEFAULT_PORT))
+            self.bootstrap_var = tk.StringVar(value=self.config_data.get('bootstrap', ''))
+            self.start_peer(auto=True)
+        else:
+            self.create_connect_frame()
+
+    def first_time_setup(self):
+        if messagebox.askyesno('Setup', f'Change default data location ({self.data_dir})?'):
+            new_dir = filedialog.askdirectory(title='Select data folder')
+            if new_dir:
+                self.data_dir = Path(new_dir)
+        self.minimize_to_tray = messagebox.askyesno('Setup', 'Allow program to run in background when window is closed?')
+
+    def save_config(self):
+        cfg_path = self.data_dir / CONFIG_FILE
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        with open(cfg_path, 'w', encoding='utf-8') as f:
+            json.dump(self.config_data, f)
 
     def create_connect_frame(self):
         frame = ttk.Frame(self)
@@ -66,20 +116,28 @@ class App(tk.Tk):
         self.inbox.grid(row=3, column=1, columnspan=2, sticky='nsew')
         frame.rowconfigure(3, weight=1)
 
-    def start_peer(self):
+    def start_peer(self, auto=False):
         username = self.username_var.get().strip()
         if not username:
             messagebox.showerror('Error', 'Username required')
             return
         port = self.port_var.get()
         bootstrap = self.bootstrap_var.get().strip() or None
-        self.peer = Peer(username, port=port)
+        profile_path = self.data_dir / f"{username}_profile.json"
+        self.peer = Peer(username, port=port, profile_path=profile_path)
         try:
             asyncio.run(self.peer.start(bootstrap))
         except Exception as exc:
             messagebox.showerror('Error', f'Could not start peer: {exc}')
             return
-        self.connect_frame.destroy()
+        self.config_data['username'] = username
+        self.config_data['port'] = port
+        self.config_data['bootstrap'] = bootstrap or ''
+        self.config_data['data_dir'] = str(self.data_dir)
+        self.config_data['minimize_to_tray'] = self.minimize_to_tray
+        self.save_config()
+        if not auto:
+            self.connect_frame.destroy()
         self.create_main_frame()
         self.after(5000, self.check_messages)
 
@@ -124,6 +182,40 @@ class App(tk.Tk):
         except Exception:
             pass
         self.after(5000, self.check_messages)
+
+    # ------------- System tray handling -------------
+    def create_tray_icon(self):
+        size = 64
+        image = Image.new('RGB', (size, size), 'white')
+        d = ImageDraw.Draw(image)
+        d.rectangle((0, 0, size, size), fill='white')
+        d.text((size//4, size//4), 'P2P', fill='black')
+        menu = pystray.Menu(pystray.MenuItem('Open', self.show_window),
+                            pystray.MenuItem('Quit', self.quit_app))
+        self.tray = pystray.Icon('p2p-social', image, 'P2P Social', menu)
+
+    def on_close(self):
+        if self.minimize_to_tray:
+            if not self.tray:
+                self.create_tray_icon()
+                self.withdraw()
+                self.tray.run_detached()
+            else:
+                self.withdraw()
+        else:
+            self.quit_app()
+
+    def show_window(self, *args):
+        self.deiconify()
+        if self.tray:
+            self.tray.stop()
+            self.tray = None
+
+    def quit_app(self, *args):
+        if self.tray:
+            self.tray.stop()
+            self.tray = None
+        self.destroy()
 
 
 def main():


### PR DESCRIPTION
## Summary
- save profile data to configurable folder for easy backup and restore
- prompt for data directory and background behaviour on first run
- autologin using saved profile
- add system tray mode when window is closed
- extend profile info with location and birthday fields
- document new workflow and FAQ
- update dependencies for pystray and Pillow

## Testing
- `python -m py_compile social_gui.py social_p2p.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687665c82e0083258adc3ce3a19d4f3b