### PR TITLE
Add profile edit options and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ python social_gui.py
 
 The first time you launch the application it will ask for a folder to store
 profile backups and whether the program should continue running in the
-<<ckground when the window is closed. It also lets you enable a Spanish
+background when the window is closed. It also lets you enable a Spanish
 translation of the interface. Once a profile has been created the application
 will automatically sign in using the saved data.
 
@@ -83,10 +83,6 @@ python web_gui.py
 ```
 
 Open `http://localhost:5000` in your browser to log in and post updates.
-=======
-background when the window is closed. Once a profile has been created the
-application will automatically sign in using the saved data.
->>>>>> main
 
 ### Command line usage (for debugging)
 
@@ -95,6 +91,12 @@ The command line script can still be used for experimenting with the network:
 ```bash
 python social_p2p.py --username alice --port 8468
 ```
+To update your profile from the command line run:
+
+```bash
+python social_p2p.py --username alice --set-about "Love P2P" --set-location "USA" --show-profile
+```
+
 
 ## FAQ
 
@@ -106,7 +108,6 @@ backup of your profile data which can be copied for safekeeping.
 data folder and ensure the configuration file points to the same username. The
 program will automatically load it on start.
 
-<<<<<< codex/enhance-user-experience-for-social-media-program
 **Is there a browser based UI?**  Yes, run `python web_gui.py` and open
 `http://localhost:5000` to use the web interface.
 
@@ -116,10 +117,3 @@ The network layer relies on the `kademlia` package to publish profile details
 and exchange messages using a DHT. The desktop GUI is built with Tkinter and
 can optionally minimize to the system tray using `pystray`. A lightweight Flask
 server hosts the optional web interface using simple HTML templates.
-=======
-## Technical Notes
-
-The network layer relies on the `kademlia` package to publish profile details
-and exchange messages using a DHT. The GUI is implemented with Tkinter and can
-optionally minimize to the system tray using `pystray`.
->>>>> main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 kademlia==2.2.3
 pystray==0.19.5
 Pillow==11.3.0
-<<<<<< codex/enhance-user-experience-for-social-media-program
 Flask==3.0.3
-=======
->>>>>> main

--- a/social_gui.py
+++ b/social_gui.py
@@ -9,7 +9,6 @@ from PIL import Image, ImageDraw
 import pystray
 from social_p2p import Peer, DEFAULT_PORT
 
-codex/enhance-user-experience-for-social-media-program
 TRANSLATIONS = {
     'en': {
         'Username:': 'Username:',
@@ -41,8 +40,6 @@ TRANSLATIONS = {
     },
 }
 
-=======
->>>>>> main
 DEFAULT_DATA_DIR = Path.home() / '.p2psocial'
 CONFIG_FILE = 'config.json'
 
@@ -68,18 +65,33 @@ class App(tk.Tk):
         self.config_data = {}
         self.data_dir = DEFAULT_DATA_DIR
         self.minimize_to_tray = False
-codex/enhance-user-experience-for-social-media-program
         self.lang = 'en'
         self.load_or_setup()
+        self.build_menu()
 
     def t(self, text: str) -> str:
         return TRANSLATIONS.get(self.lang, TRANSLATIONS['en']).get(text, text)
 
-=======
-        self.load_or_setup()
-
->>>>>> main
     # -------- Configuration management ---------
+    def build_menu(self):
+        menubar = tk.Menu(self)
+        lang_menu = tk.Menu(menubar, tearoff=False)
+        lang_menu.add_command(label='English', command=lambda: self.change_language('en'))
+        lang_menu.add_command(label='Español', command=lambda: self.change_language('es'))
+        menubar.add_cascade(label='Language', menu=lang_menu)
+        self.config(menu=menubar)
+
+    def change_language(self, lang: str):
+        self.lang = lang
+        self.config_data['lang'] = lang
+        self.save_config()
+        if hasattr(self, 'connect_frame') and self.connect_frame.winfo_exists():
+            self.connect_frame.destroy()
+            self.create_connect_frame()
+        if hasattr(self, 'main_frame') and self.main_frame.winfo_exists():
+            self.main_frame.destroy()
+            self.create_main_frame()
+
     def load_or_setup(self):
         cfg_path = self.data_dir / CONFIG_FILE
         if cfg_path.exists():
@@ -87,10 +99,7 @@ codex/enhance-user-experience-for-social-media-program
                 self.config_data = json.load(open(cfg_path, 'r', encoding='utf-8'))
                 self.minimize_to_tray = self.config_data.get('minimize_to_tray', False)
                 self.data_dir = Path(self.config_data.get('data_dir', self.data_dir))
- codex/enhance-user-experience-for-social-media-program
                 self.lang = self.config_data.get('lang', 'en')
-
- main
             except Exception:
                 self.config_data = {}
         else:
@@ -112,19 +121,13 @@ codex/enhance-user-experience-for-social-media-program
             if new_dir:
                 self.data_dir = Path(new_dir)
         self.minimize_to_tray = messagebox.askyesno('Setup', 'Allow program to run in background when window is closed?')
-<<<<<< codex/enhance-user-experience-for-social-media-program
         if messagebox.askyesno('Language', 'Use Spanish interface?'):
             self.lang = 'es'
-=======
->>>>>> main
 
     def save_config(self):
         cfg_path = self.data_dir / CONFIG_FILE
         self.data_dir.mkdir(parents=True, exist_ok=True)
-< codex/enhance-user-experience-for-social-media-program
         self.config_data['lang'] = self.lang
-=
- main
         with open(cfg_path, 'w', encoding='utf-8') as f:
             json.dump(self.config_data, f)
 
@@ -261,7 +264,6 @@ codex/enhance-user-experience-for-social-media-program
             pass
         self.after(5000, self.check_messages)
 
-<<<<<< codex/enhance-user-experience-for-social-media-program
     def refresh_posts(self):
         try:
             posts = asyncio.run(self.peer.fetch_posts(self.peer.username))
@@ -274,8 +276,6 @@ codex/enhance-user-experience-for-social-media-program
             pass
         self.after(5000, self.refresh_posts)
 
-=======
->>>>>> main
     # ------------- System tray handling -------------
     def create_tray_icon(self):
         size = 64

--- a/social_p2p.py
+++ b/social_p2p.py
@@ -1,10 +1,7 @@
 import asyncio
 import json
 from dataclasses import dataclass, asdict
-<<<<<< codex/enhance-user-experience-for-social-media-program
 from datetime import datetime
-=======
->>>>>> main
 from pathlib import Path
 from kademlia.network import Server
 
@@ -48,7 +45,6 @@ class Profile:
         with open(path, 'w', encoding='utf-8') as f:
             f.write(self.to_json())
 
-<<<<<< codex/enhance-user-experience-for-social-media-program
 
 @dataclass
 class Post:
@@ -64,8 +60,6 @@ class Post:
     def from_dict(data: dict):
         return Post(**data)
 
-=======
->>>>>> main
 class Peer:
     def __init__(self, username, port=DEFAULT_PORT, profile_path: Path | None = None):
         self.username = username
@@ -79,10 +73,7 @@ class Peer:
             self.profile = Profile(username=username, visibility={})
             if profile_path:
                 self.profile.save(profile_path)
-<<<<<< codex/enhance-user-experience-for-social-media-program
         self.post_key = f'posts:{self.username}'
-=======
->>>>>> main
 
     async def start(self, bootstrap_node=None):
         await self.server.listen(self.port)
@@ -159,13 +150,14 @@ async def main():
     parser.add_argument('--message', help='Send message text (requires --lookup)')
     parser.add_argument('--fetch', action='store_true', help='Fetch queued messages')
     parser.add_argument('--profile-dir', help='Directory to store local profile data')
-<<<<<< codex/enhance-user-experience-for-social-media-program
     parser.add_argument('--post', help='Text of status update to publish')
     parser.add_argument('--get-posts', help='Fetch posts from a user')
     parser.add_argument('--like', nargs=2, metavar=('USER', 'TIMESTAMP'),
                         help='Like a post from USER with given TIMESTAMP')
-=======
->>>>>> main
+    parser.add_argument('--set-about', help='Update your about section')
+    parser.add_argument('--set-website', help='Update your website URL')
+    parser.add_argument('--set-location', help='Update your location')
+    parser.add_argument('--show-profile', action='store_true', help='Display your profile after updates')
     args = parser.parse_args()
 
     profile_path = None
@@ -173,6 +165,23 @@ async def main():
         profile_path = Path(args.profile_dir) / f"{args.username}_profile.json"
     peer = Peer(args.username, port=args.port, profile_path=profile_path)
     await peer.start(args.bootstrap)
+
+    updated = False
+    if args.set_about:
+        peer.profile.about = args.set_about
+        updated = True
+    if args.set_website:
+        peer.profile.website = args.set_website
+        updated = True
+    if args.set_location:
+        peer.profile.location = args.set_location
+        updated = True
+    if updated:
+        await peer.publish_profile()
+        print('Profile updated.')
+
+    if args.show_profile:
+        print(peer.profile)
 
     if args.post:
         await peer.add_post(args.post)


### PR DESCRIPTION
## Summary
- clean leftover merge markers across project
- extend command line client with profile editing options
- add dynamic language menu to the GUI
- document new commands in README

## Testing
- `python -m py_compile social_p2p.py`
- `python -m py_compile social_gui.py`
- `python -m py_compile web_gui.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687674416a288325a1aaa4baba4ab4c0